### PR TITLE
Phase2/2 b qclient

### DIFF
--- a/docs/designdoc.md
+++ b/docs/designdoc.md
@@ -23,8 +23,8 @@ Login/OAuth            SQL Generator         File Output
 
 - **CLI / Chat インターフェース**: ユーザーからの自然言語入力を受け取り、指示結果を表示する。
 - **LLM Engine**: 入力とメタデータを元に SQL を生成し、ユーザーに提示する。分析や可視化向けのプロンプトを扱うモジュールに分割される。
-- **BigQuery API クライアント**: 認証済みアカウントで SQL を実行し、結果を取得する。
-- **Metadata Manager**: BigQuery のテーブル構造やサンプル値を読み取り、`data.md` として保存する。
+- **BigQuery API クライアント**: 認証済みアカウントで SQL を実行し、結果を取得する。また、メタデータ取得（datasets/tables/schema/samples）も提供する。
+- **Metadata Manager**: BigQuery クライアントから取得したスナップショットを用いて、テーブル構造やサンプル値を `metadata.md` としてレンダリング・保存する。
 - **Data Store**: クエリ結果やメタデータ、可視化画像をフォルダに保存する。
 - **Analysis Processor**: 保存済み CSV を読み込み、LLM を介して示唆を Markdown に出力する。
 - **Visualization Engine**: 指示に応じてグラフを描画し、画像として保存する。

--- a/docs/tasks/phase2_1.md
+++ b/docs/tasks/phase2_1.md
@@ -8,7 +8,7 @@
 
 ## ステータス
 
-ongoing
+completed
 
 ## 実施内容（2025-09-14）
 
@@ -16,10 +16,10 @@ ongoing
   - ブラウザでの Google OAuth を実行し、取得したリフレッシュトークンと email を DB に保存。
   - 実装箇所: `wise/auth/google.py`（OAuth 実装）、`wise/chat/session.py` の `_run_setup_wizard()`（OAuth 呼び出し）。
 - セットアップ完了後のチャットへの移行処理を実装。
-  - アカウント確認→なければウィザード→`sessions` 作成→チャットループ開始（メッセージは DB 保存）。
+  - アカウント確認 → なければウィザード →`sessions` 作成 → チャットループ開始（メッセージは DB 保存）。
   - 実装箇所: `wise/chat/session.py: start_session()`。
 - CLI 入口をチャットセッションに接続。
-  - 実装箇所: `wise/cli.py`（DB 初期化→`start_session()` を呼び出し）。
+  - 実装箇所: `wise/cli.py`（DB 初期化 →`start_session()` を呼び出し）。
 - 再ログインコマンドを OAuth 化。
   - `/login` / `/reauth` でブラウザ認証し、トークンを保存。
   - 実装箇所: `wise/chat/commands.py`。
@@ -32,7 +32,7 @@ ongoing
 
 ## 次アクション候補
 
-- OAuth フローの実装（ブラウザ起動→リフレッシュトークン取得→`accounts` 保存）。
+- OAuth フローの実装（ブラウザ起動 → リフレッシュトークン取得 →`accounts` 保存）。
 - `/login` に OAuth 起動を統合し、暫定入力を置き換え。
 
 ## 動作確認方法（現時点）
@@ -52,6 +52,7 @@ ongoing
   - 終了は `exit` または `quit`。
 
 注意: BigQuery API 呼び出しは未配線です（次ステップ）。仕様は `docs/research/auth_bq.md` を参照してください。
+
 - BQ クライアントの実配線（`wise/bq/client.py` 置換）。
 
 ## 提案（要確認）

--- a/docs/tasks/phase2_2.md
+++ b/docs/tasks/phase2_2.md
@@ -1,0 +1,75 @@
+## フェーズ 2: 認証と BigQuery 接続
+
+## 目的
+
+**BigQuery クライアントの作成**
+
+- 認証情報から BigQuery API を呼び出すラッパー `bq/client.py` を実装。
+
+## ステータス
+
+completed
+
+## 実装計画
+
+### 方針
+
+- BQ との疎通（メタデータ取得と SQL 実行）を単一のクライアント `wise/bq/client.py` に集約する。
+- 認証は `/login` で取得・保存した `refresh_token` と `cred.json` の `client_id/client_secret` を使い、`google-auth` でアクセストークンを都度リフレッシュ。
+- ライブラリは `google-cloud-bigquery` は使わず、REST + `AuthorizedSession` で実装（既存依存のまま動作）。
+
+### 提供 I/F（例）
+
+- クラス: `BQClient(project_id: str, account_id: Optional[int] = None, location: str = "US")`
+
+  - `list_datasets() -> list[str]`
+  - `list_tables(dataset_id: str) -> list[str]`
+  - `get_table_schema(dataset_id: str, table_id: str) -> list[dict]`
+  - `sample_rows(dataset_id: str, table_id: str, max_results: int = 5) -> list[dict]`
+  - `run_sql(sql: str, *, max_results: int = 1000, dry_run: bool = False, fetch_all: bool = True) -> dict`
+    - 返り値: `{ schema: [fields], rows: [dict], totalRows: int, jobId: str }`
+
+- 便宜関数:
+  - `query(sql: str, *, project_id: str, account_id: Optional[int] = None, ...) -> list[dict]`
+  - `metadata_snapshot(project_id: str, *, datasets: Optional[list[str]] = None, sample_n: int = 3) -> dict`
+
+### 使用エンドポイント（REST）
+
+- `GET  https://bigquery.googleapis.com/bigquery/v2/projects/{project}/datasets`
+- `GET  https://bigquery.googleapis.com/bigquery/v2/projects/{project}/datasets/{dataset}/tables`
+- `GET  https://bigquery.googleapis.com/bigquery/v2/projects/{project}/datasets/{dataset}/tables/{table}`（schema）
+- `GET  https://bigquery.googleapis.com/bigquery/v2/projects/{project}/datasets/{dataset}/tables/{table}/data`（サンプル）
+- `POST https://bigquery.googleapis.com/bigquery/v2/projects/{project}/queries`（jobs.query）
+- `GET  https://bigquery.googleapis.com/bigquery/v2/projects/{project}/queries/{jobId}`（ページング）
+
+### 認証
+
+- DB（`accounts`）に保存済みの `refresh_token` を取得。
+- `cred.json`（または `WISE_GOOGLE_CLIENT_SECRETS`）から `client_id/client_secret/token_uri` を読み取り、`Credentials(...).refresh(Request())` でアクセストークン取得。
+- `AuthorizedSession` を再利用して API 呼び出し。
+
+### `metadata/` の責務
+
+（今回の実装では触らないが、今後を視野に入れた責務についての記述）
+
+- `metadata_snapshot(...)` で取得したスナップショット（プロジェクト/データセット/テーブル/スキーマ/サンプル行）を受け取り、`metadata.md` にレンダリング・保存する（`metadata/manager.py`）。
+- 再実行時はファイルを上書き（後続で差分マージの検討余地あり）。
+
+### 受け入れ基準（最低限）
+
+- `/login` 済みの環境で `BQClient(project_id).list_datasets()` が 200 レスポンスとなり dataset 一覧が取得できる。
+- `BQClient(project_id).run_sql("SELECT 1 AS x")` が `rows=[{"x": "1"}]` のように行データを返す。
+- `metadata_snapshot(project_id, sample_n=3)` がスキーマとサンプル行を含む辞書を返す。
+
+### 動作確認手順（例）
+
+1. `wise login`（もしくは `/login`）で Google 認証を完了させ、`accounts.refresh_token` を保存。
+2. Python REPL などで次を実行:
+   - `from wise.bq.client import BQClient; BQClient(project_id="<PJ>").list_datasets()`
+   - `BQClient(project_id="<PJ>").run_sql("SELECT 1 AS x")`
+   - `from wise.metadata.manager import generate_and_save; generate_and_save(project_id="<PJ>")`
+
+### 備考
+
+- 依存追加は不要（`google-auth`, `google-auth-oauthlib` のみ）。
+- 複雑なネストスキーマ（RECORD/REPEATED）は段階的に対応（まずはフラット型をサポート）。

--- a/wise/bq/client.py
+++ b/wise/bq/client.py
@@ -1,9 +1,423 @@
-"""BigQuery client placeholder."""
+"""BigQuery REST client used by the wise CLI.
+
+This module talks directly to BigQuery's REST API by combining
+google-auth refreshable credentials with ``AuthorizedSession``. The
+implementation intentionally avoids ``google-cloud-bigquery`` so that the
+project can stay within the lightweight dependency set defined in the
+design doc.
+"""
 
 from __future__ import annotations
 
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Iterable, Optional
 
-def query(sql: str) -> list[dict]:
-    """Return mock rows for a SQL query."""
-    _ = sql
-    return []
+from google.auth.transport.requests import AuthorizedSession, Request
+from google.oauth2.credentials import Credentials
+
+from ..auth.google import SCOPES
+from ..db import models
+
+__all__ = [
+    "BQClient",
+    "BigQueryClientError",
+    "metadata_snapshot",
+    "query",
+]
+
+
+class BigQueryClientError(RuntimeError):
+    """Raised when the BigQuery REST API or credential setup fails."""
+
+    def __init__(self, message: str, *, status_code: int | None = None, payload: Any | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.payload = payload
+
+
+class BQClient:
+    """Minimal BigQuery REST client for metadata operations and SQL execution."""
+
+    BASE_URL = "https://bigquery.googleapis.com/bigquery/v2"
+    DEFAULT_TIMEOUT = 30
+    POLL_INTERVAL_SEC = 1.0
+    MAX_POLL_ATTEMPTS = 30
+
+    def __init__(
+        self,
+        project_id: str,
+        account_id: Optional[int] = None,
+        location: str = "US",
+        *,
+        db_path: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> None:
+        if not project_id:
+            raise ValueError("project_id は必須です。")
+
+        self.project_id = project_id
+        self.location = location
+        self.account_id: int
+        self._db_path = db_path
+        self._timeout = timeout if timeout is not None else self.DEFAULT_TIMEOUT
+
+        self._client_info = self._load_client_info()
+        account = self._resolve_account(account_id)
+        self.account_id = int(account["id"])
+        refresh_token = account["refresh_token"]
+        if not refresh_token:
+            raise BigQueryClientError("指定されたアカウントに refresh_token が保存されていません。")
+
+        self._credentials = self._build_credentials(refresh_token)
+        self._session = AuthorizedSession(self._credentials)
+
+    # ----------
+    # Public API
+    # ----------
+
+    def list_datasets(self) -> list[str]:
+        """Return dataset IDs available in the configured project."""
+
+        path = f"/projects/{self.project_id}/datasets"
+        params = {"maxResults": 1000}
+        dataset_ids: list[str] = []
+        for page in self._paginate(path, params=params):
+            for ds in page.get("datasets", []):
+                ref = ds.get("datasetReference", {})
+                dataset_id = ref.get("datasetId")
+                if dataset_id:
+                    dataset_ids.append(dataset_id)
+        return dataset_ids
+
+    def list_tables(self, dataset_id: str) -> list[str]:
+        """Return table IDs for a given dataset."""
+
+        if not dataset_id:
+            raise ValueError("dataset_id は必須です。")
+        path = f"/projects/{self.project_id}/datasets/{dataset_id}/tables"
+        params = {"maxResults": 1000}
+        table_ids: list[str] = []
+        for page in self._paginate(path, params=params):
+            for table in page.get("tables", []):
+                ref = table.get("tableReference", {})
+                table_id = ref.get("tableId")
+                if table_id:
+                    table_ids.append(table_id)
+        return table_ids
+
+    def get_table_schema(self, dataset_id: str, table_id: str) -> list[dict[str, Any]]:
+        """Return BigQuery field definitions for the specified table."""
+
+        if not dataset_id or not table_id:
+            raise ValueError("dataset_id と table_id は必須です。")
+        path = f"/projects/{self.project_id}/datasets/{dataset_id}/tables/{table_id}"
+        data = self._request("GET", path)
+        schema = (data.get("schema") or {}).get("fields")
+        return list(schema or [])
+
+    def sample_rows(self, dataset_id: str, table_id: str, max_results: int = 5) -> list[dict[str, Any]]:
+        """Fetch up to ``max_results`` rows from the table using the data endpoint."""
+
+        if max_results <= 0:
+            return []
+        path = f"/projects/{self.project_id}/datasets/{dataset_id}/tables/{table_id}/data"
+        params = {"maxResults": max_results}
+        data = self._request("GET", path, params=params)
+        schema_fields = (data.get("schema") or {}).get("fields") or []
+        rows = data.get("rows") or []
+        return self._format_rows(rows, schema_fields)
+
+    def run_sql(
+        self,
+        sql: str,
+        *,
+        max_results: int = 1000,
+        dry_run: bool = False,
+        fetch_all: bool = True,
+    ) -> dict[str, Any]:
+        """Execute SQL via ``jobs.query`` and return schema/rows metadata."""
+
+        if not sql:
+            raise ValueError("SQL 文が空です。")
+        payload: dict[str, Any] = {
+            "query": sql,
+            "useLegacySql": False,
+            "location": self.location,
+            "maxResults": max_results,
+            "dryRun": dry_run,
+        }
+        data = self._request("POST", f"/projects/{self.project_id}/queries", json=payload)
+
+        job = data.get("jobReference", {})
+        job_id = job.get("jobId")
+        if not job_id:
+            raise BigQueryClientError("jobs.query の応答に jobId が含まれていません。", payload=data)
+
+        schema_fields = (data.get("schema") or {}).get("fields") or []
+        total_rows = self._coerce_int(data.get("totalRows"))
+        rows: list[dict[str, Any]] = []
+
+        if not dry_run:
+            rows.extend(self._format_rows(data.get("rows") or [], schema_fields))
+            page_token = self._next_page_token(data)
+            job_complete = data.get("jobComplete", True)
+
+            if not job_complete:
+                # Wait for the job to finish before returning rows.
+                finished = self._poll_for_completion(job_id, max_results=max_results)
+                if finished.get("schema") and not schema_fields:
+                    schema_fields = (finished.get("schema") or {}).get("fields") or schema_fields
+                rows.extend(self._format_rows(finished.get("rows") or [], schema_fields))
+                total_rows = self._coerce_int(finished.get("totalRows") or total_rows)
+                page_token = self._next_page_token(finished)
+                job_complete = finished.get("jobComplete", True)
+
+            if fetch_all and page_token:
+                rows.extend(
+                    self._fetch_remaining_rows(
+                        job_id,
+                        schema_fields=schema_fields,
+                        start_token=page_token,
+                        max_results=max_results,
+                    )
+                )
+        result = {
+            "schema": schema_fields,
+            "rows": rows,
+            "totalRows": total_rows,
+            "jobId": job_id,
+        }
+        return result
+
+    # ---------------
+    # Helper routines
+    # ---------------
+
+    def _resolve_account(self, account_id: Optional[int]) -> Any:
+        accounts = models.list_accounts(db_path=self._db_path)
+        if account_id is not None:
+            for row in accounts:
+                if int(row["id"]) == int(account_id):
+                    return row
+            raise BigQueryClientError(f"account_id={account_id} が見つかりません。'wise login' を実行して認証してください。")
+
+        for row in accounts:
+            if row["refresh_token"]:
+                return row
+        raise BigQueryClientError("利用可能なアカウントが見つかりません。'wise login' で認証してください。")
+
+    def _load_client_info(self) -> dict[str, str]:
+        env_path = os.getenv("WISE_GOOGLE_CLIENT_SECRETS")
+        candidate: Optional[Path] = Path(env_path) if env_path else None
+        if not candidate:
+            cwd = Path.cwd()
+            for name in ("cred.json", "client_secrets.json"):
+                p = cwd / name
+                if p.exists():
+                    candidate = p
+                    break
+            if not candidate:
+                candidate = cwd / "cred.json"
+
+        if not candidate.exists():
+            raise BigQueryClientError(
+                f"OAuth クライアントシークレットが見つかりません: {candidate}."
+                " 環境変数 WISE_GOOGLE_CLIENT_SECRETS または ./cred.json を配置してください。"
+            )
+
+        with candidate.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if "installed" in data:
+            config = data["installed"]
+        elif "web" in data:
+            config = data["web"]
+        else:
+            config = data
+
+        missing = [key for key in ("client_id", "client_secret", "token_uri") if key not in config]
+        if missing:
+            joined = ", ".join(missing)
+            raise BigQueryClientError(f"OAuth クライアント設定に不足項目があります: {joined}")
+        return config
+
+    def _build_credentials(self, refresh_token: str) -> Credentials:
+        try:
+            creds = Credentials(
+                token=None,
+                refresh_token=refresh_token,
+                client_id=self._client_info["client_id"],
+                client_secret=self._client_info["client_secret"],
+                token_uri=self._client_info["token_uri"],
+                scopes=SCOPES,
+            )
+            creds.refresh(Request())
+        except Exception as exc:  # pragma: no cover - network failure is rare
+            raise BigQueryClientError("アクセストークンのリフレッシュに失敗しました。") from exc
+        return creds
+
+    def _full_url(self, path: str) -> str:
+        return f"{self.BASE_URL}{path}"
+
+    def _request(self, method: str, path: str, *, params: Optional[dict[str, Any]] = None, json: Any = None) -> dict[str, Any]:
+        url = self._full_url(path)
+        response = self._session.request(
+            method,
+            url,
+            params=params,
+            json=json,
+            timeout=self._timeout,
+        )
+        if response.status_code >= 400:
+            try:
+                payload = response.json()
+            except ValueError:
+                payload = response.text
+            raise BigQueryClientError(
+                f"BigQuery API 呼び出しエラー ({response.status_code})", status_code=response.status_code, payload=payload
+            )
+        if not response.content:
+            return {}
+        try:
+            return response.json()
+        except ValueError as exc:  # pragma: no cover - unexpected server bug
+            raise BigQueryClientError("BigQuery API の応答を JSON として解析できませんでした。") from exc
+
+    def _paginate(self, path: str, *, params: Optional[dict[str, Any]] = None) -> Iterable[dict[str, Any]]:
+        token: Optional[str] = None
+        base_params = params or {}
+        while True:
+            query = dict(base_params)
+            if token:
+                query["pageToken"] = token
+            data = self._request("GET", path, params=query)
+            yield data
+            token = self._next_page_token(data)
+            if not token:
+                break
+
+    def _poll_for_completion(self, job_id: str, *, max_results: int) -> dict[str, Any]:
+        attempts = 0
+        while True:
+            if attempts >= self.MAX_POLL_ATTEMPTS:
+                raise BigQueryClientError("BigQuery ジョブが完了しませんでした (タイムアウト)。")
+            time.sleep(self.POLL_INTERVAL_SEC)
+            data = self._request(
+                "GET",
+                f"/projects/{self.project_id}/queries/{job_id}",
+                params={"maxResults": max_results, "location": self.location},
+            )
+            if data.get("jobComplete", True):
+                return data
+            attempts += 1
+
+    def _fetch_remaining_rows(
+        self,
+        job_id: str,
+        *,
+        schema_fields: list[dict[str, Any]],
+        start_token: str,
+        max_results: int,
+    ) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        token: Optional[str] = start_token
+        while token:
+            data = self._request(
+                "GET",
+                f"/projects/{self.project_id}/queries/{job_id}",
+                params={
+                    "maxResults": max_results,
+                    "pageToken": token,
+                    "location": self.location,
+                },
+            )
+            if data.get("schema") and not schema_fields:
+                schema_fields[:] = (data.get("schema") or {}).get("fields") or []
+            rows.extend(self._format_rows(data.get("rows") or [], schema_fields))
+            token = self._next_page_token(data)
+        return rows
+
+    @staticmethod
+    def _next_page_token(data: dict[str, Any]) -> Optional[str]:
+        return data.get("pageToken") or data.get("nextPageToken")
+
+    @staticmethod
+    def _coerce_int(value: Any) -> int:
+        if value is None:
+            return 0
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _format_rows(rows: Iterable[Any], schema_fields: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        if not rows or not schema_fields:
+            return []
+        names = [field.get("name") for field in schema_fields]
+        formatted: list[dict[str, Any]] = []
+        for row in rows:
+            cells = row.get("f", []) if isinstance(row, dict) else []
+            mapped: dict[str, Any] = {}
+            for idx, name in enumerate(names):
+                if not name:
+                    continue
+                if idx < len(cells):
+                    mapped[name] = cells[idx].get("v")
+                else:
+                    mapped[name] = None
+            formatted.append(mapped)
+        return formatted
+
+
+def query(
+    sql: str,
+    *,
+    project_id: str,
+    account_id: Optional[int] = None,
+    location: str = "US",
+    max_results: int = 1000,
+    dry_run: bool = False,
+    fetch_all: bool = True,
+) -> list[dict[str, Any]]:
+    """Convenience wrapper that returns only the rows from ``run_sql``."""
+
+    client = BQClient(project_id=project_id, account_id=account_id, location=location)
+    result = client.run_sql(sql, max_results=max_results, dry_run=dry_run, fetch_all=fetch_all)
+    return result.get("rows", [])
+
+
+def metadata_snapshot(
+    project_id: str,
+    *,
+    account_id: Optional[int] = None,
+    location: str = "US",
+    datasets: Optional[list[str]] = None,
+    sample_n: int = 3,
+) -> dict[str, Any]:
+    """Collect datasets/tables/schema/sample rows for later rendering."""
+
+    client = BQClient(project_id=project_id, account_id=account_id, location=location)
+    dataset_ids = datasets or client.list_datasets()
+
+    snapshot: dict[str, Any] = {
+        "projectId": project_id,
+        "location": location,
+        "datasets": {},
+    }
+
+    for dataset_id in dataset_ids:
+        tables = client.list_tables(dataset_id)
+        dataset_entry: dict[str, Any] = {"tables": {}}
+        for table_id in tables:
+            schema = client.get_table_schema(dataset_id, table_id)
+            samples = client.sample_rows(dataset_id, table_id, max_results=sample_n)
+            dataset_entry["tables"][table_id] = {
+                "schema": schema,
+                "sampleRows": samples,
+            }
+        snapshot["datasets"][dataset_id] = dataset_entry
+
+    return snapshot


### PR DESCRIPTION
This pull request updates documentation to reflect the completion and implementation details of Phase 2, focusing on BigQuery authentication and client integration. The main changes clarify the role of the BigQuery client, update status and implementation progress, and introduce a new design document for Phase 2.

**BigQuery Client Integration and Documentation Updates:**

* Updated the system design in `docs/designdoc.md` to clarify that the BigQuery API client now also handles metadata retrieval and that the Metadata Manager uses snapshots from the client to render and save table structures and sample values as `metadata.md`.

* Marked Phase 2.1 as completed in `docs/tasks/phase2_1.md` and added a note about the actual wiring of the BigQuery client (`wise/bq/client.py`). [[1]](diffhunk://#diff-048e43069cc5ca28094ff007dea0532a61a1db09019933fed4b91c484c6c8859L11-R11) [[2]](diffhunk://#diff-048e43069cc5ca28094ff007dea0532a61a1db09019933fed4b91c484c6c8859R55)

**New Implementation Plan for BigQuery Authentication:**

* Added a new document `docs/tasks/phase2_2.md` detailing the objectives, implementation plan, authentication flow, provided interfaces, REST endpoints, and acceptance criteria for the unified BigQuery client (`wise/bq/client.py`). This includes sample methods, authentication steps, and usage examples.