### PR TITLE
Implement /init BigQuery metadata initialization flow

### DIFF
--- a/tests/test_chat_commands.py
+++ b/tests/test_chat_commands.py
@@ -1,0 +1,149 @@
+import sys
+import types
+
+
+def _install_google_stubs() -> None:
+    google_module = types.ModuleType("google")
+    auth_module = types.ModuleType("google.auth")
+    transport_module = types.ModuleType("google.auth.transport")
+    requests_module = types.ModuleType("google.auth.transport.requests")
+
+    class _Request:  # pragma: no cover - simple stub
+        pass
+
+    class _AuthorizedSession:  # pragma: no cover - simple stub
+        def __init__(self, *args, **kwargs) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+        def request(self, *args, **kwargs):
+            raise RuntimeError("Network access not available in tests")
+
+    requests_module.Request = _Request
+    requests_module.AuthorizedSession = _AuthorizedSession
+
+    oauth_module = types.ModuleType("google.oauth2")
+    credentials_module = types.ModuleType("google.oauth2.credentials")
+    oauthlib_module = types.ModuleType("google_auth_oauthlib")
+    oauthlib_flow_module = types.ModuleType("google_auth_oauthlib.flow")
+
+    class _Credentials:  # pragma: no cover - simple stub
+        def __init__(self, *args, **kwargs) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+        def refresh(self, *args, **kwargs) -> None:
+            return None
+
+    credentials_module.Credentials = _Credentials
+
+    class _InstalledAppFlow:  # pragma: no cover - simple stub
+        @classmethod
+        def from_client_secrets_file(cls, *args, **kwargs):
+            return cls()
+
+        def run_local_server(self, *args, **kwargs):
+            class _Creds:  # pragma: no cover - simple stub
+                refresh_token = "stub-token"
+
+            return _Creds()
+
+    oauthlib_flow_module.InstalledAppFlow = _InstalledAppFlow
+    oauthlib_module.flow = oauthlib_flow_module
+
+    google_module.auth = auth_module
+    google_module.oauth2 = oauth_module
+
+    sys.modules.setdefault("google", google_module)
+    sys.modules.setdefault("google.auth", auth_module)
+    sys.modules.setdefault("google.auth.transport", transport_module)
+    sys.modules.setdefault("google.auth.transport.requests", requests_module)
+    sys.modules.setdefault("google.oauth2", oauth_module)
+    sys.modules.setdefault("google.oauth2.credentials", credentials_module)
+    sys.modules.setdefault("google_auth_oauthlib", oauthlib_module)
+    sys.modules.setdefault("google_auth_oauthlib.flow", oauthlib_flow_module)
+
+
+_install_google_stubs()
+
+from wise.chat import commands
+from wise.metadata import manager as metadata_manager
+
+
+def test_init_requires_login(monkeypatch):
+    monkeypatch.setattr(commands.models, "list_accounts", lambda: [])
+    message = commands._init()
+    assert "login" in message
+
+
+def test_init_happy_path(monkeypatch, tmp_path):
+    monkeypatch.setattr(commands.models, "list_accounts", lambda: [{"id": 1, "refresh_token": "tok"}])
+
+    projects = [{"projectId": "demo", "friendlyName": "Demo Project"}]
+    monkeypatch.setattr(commands.bq_client, "list_projects", lambda account_id: projects)
+
+    class DummyClient:
+        def __init__(self, project_id: str, account_id: int):
+            self.project_id = project_id
+            self.account_id = account_id
+            self.location = "US"
+
+        def list_datasets(self):
+            return ["sales", "marketing"]
+
+    monkeypatch.setattr(commands.bq_client, "BQClient", DummyClient)
+
+    captured = {}
+
+    def fake_metadata_snapshot(**kwargs):
+        captured.update(kwargs)
+        return {"projectId": kwargs["project_id"], "location": kwargs.get("location"), "datasets": {}}
+
+    monkeypatch.setattr(commands.bq_client, "metadata_snapshot", fake_metadata_snapshot)
+
+    save_path = tmp_path / "project" / "demo" / "metadata.md"
+    monkeypatch.setattr(
+        commands.metadata_manager,
+        "save_metadata",
+        lambda snapshot: metadata_manager.MetadataWriteResult(path=save_path, backup_path=None),
+    )
+
+    inputs = iter(["1", ""])
+    monkeypatch.setattr(commands, "_prompt_user", lambda _: next(inputs))
+
+    message = commands._init()
+
+    assert "metadata.md" in message
+    assert captured["datasets"] == ["sales", "marketing"]
+    assert captured["sample_n"] == 3
+    assert captured["project_id"] == "demo"
+    assert captured["account_id"] == 1
+
+
+def test_init_cancelled(monkeypatch):
+    monkeypatch.setattr(commands.models, "list_accounts", lambda: [{"id": 1, "refresh_token": "tok"}])
+    monkeypatch.setattr(commands.bq_client, "list_projects", lambda account_id: [{"projectId": "demo"}])
+
+    created = {"client": False}
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            created["client"] = True
+
+        def list_datasets(self):  # pragma: no cover - should not be called
+            return []
+
+    monkeypatch.setattr(commands.bq_client, "BQClient", DummyClient)
+    monkeypatch.setattr(commands, "_prompt_user", lambda _: "")
+
+    message = commands._init()
+
+    assert "キャンセル" in message
+    assert created["client"] is False
+
+
+def test_handle_command_routes_init(monkeypatch):
+    monkeypatch.setattr(commands, "_init", lambda: "done")
+    handled, reply = commands.handle_command("/init")
+    assert handled is True
+    assert reply == "done"

--- a/tests/test_metadata_manager.py
+++ b/tests/test_metadata_manager.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+import textwrap
+
+import pytest
+
+from wise.metadata import manager
+
+
+@pytest.fixture()
+def sample_snapshot():
+    return {
+        "projectId": "demo",
+        "location": "US",
+        "datasets": {
+            "sales": {
+                "tables": {
+                    "orders": {
+                        "schema": [
+                            {
+                                "name": "order_id",
+                                "type": "STRING",
+                                "mode": "REQUIRED",
+                                "description": "注文ID",
+                            },
+                            {
+                                "name": "amount",
+                                "type": "INTEGER",
+                                "mode": "NULLABLE",
+                                "description": "",
+                            },
+                        ],
+                        "sampleRows": [
+                            {"order_id": "A-001", "amount": 100},
+                            {"order_id": "A-002", "amount": 200},
+                        ],
+                    }
+                }
+            }
+        },
+    }
+
+
+def test_render_metadata_snapshot(monkeypatch, sample_snapshot):
+    monkeypatch.setattr(manager, "_current_timestamp", lambda: "2024-01-01T00:00:00Z")
+    markdown = manager.render_metadata(sample_snapshot)
+    expected = textwrap.dedent(
+        """
+        # BigQuery メタデータ: `demo`
+
+        ## プロジェクト概要
+
+        - プロジェクト ID: `demo`
+        - ロケーション: `US`
+        - データセット数: 1
+        - 生成日時 (UTC): 2024-01-01T00:00:00Z
+
+        ## 対象データセット一覧
+
+        | データセット ID | テーブル数 |
+        | --- | --- |
+        | `sales` | 1 |
+
+        
+        ## データセット `sales`
+
+        
+        ### テーブル `sales.orders`
+
+        #### フィールド定義
+
+        | 名前 | 型 | モード | 説明 |
+        | --- | --- | --- | --- |
+        | order_id | STRING | REQUIRED | 注文ID |
+        | amount | INTEGER | NULLABLE |  |
+
+        
+        #### サンプル行
+
+        | order_id | amount |
+        | --- | --- |
+        | A-001 | 100 |
+        | A-002 | 200 |
+        """
+    ).strip()
+    assert markdown.strip() == expected
+
+
+def test_save_metadata_creates_backup(tmp_path: Path, monkeypatch, sample_snapshot):
+    monkeypatch.setattr(manager, "_current_timestamp", lambda: "2024-01-01T00:00:00Z")
+    result = manager.save_metadata(sample_snapshot, base_dir=tmp_path)
+    metadata_path = tmp_path / "project" / "demo" / "metadata.md"
+    assert result.path == metadata_path
+    assert metadata_path.exists()
+    assert result.backup_path is None
+
+    metadata_path.write_text("previous content", encoding="utf-8")
+    monkeypatch.setattr(manager, "_current_timestamp", lambda: "2024-01-02T00:00:00Z")
+    monkeypatch.setattr(manager.datastore_files, "_timestamp_for_backup", lambda: "20240102T000000")
+
+    result2 = manager.save_metadata(sample_snapshot, base_dir=tmp_path)
+    assert result2.backup_path == metadata_path.with_name("metadata.md.bak.20240102T000000")
+    assert result2.backup_path.read_text(encoding="utf-8") == "previous content"
+    assert metadata_path.read_text(encoding="utf-8").startswith("# BigQuery メタデータ")

--- a/wise/chat/commands.py
+++ b/wise/chat/commands.py
@@ -2,6 +2,7 @@
 
 Currently supports:
 - ``\login``: Re-run minimal setup to update the refresh token
+- ``\init``: Generate BigQuery metadata markdown via the metadata manager
 """
 
 from __future__ import annotations
@@ -9,6 +10,129 @@ from __future__ import annotations
 from typing import Tuple
 
 from ..auth import run_oauth_and_save_account
+from ..bq import client as bq_client
+from ..db import models
+from ..metadata import manager as metadata_manager
+
+
+def _prompt_user(prompt: str) -> str:
+    return input(prompt)
+
+
+def _active_account_id() -> int | None:
+    for row in models.list_accounts():
+        if row["refresh_token"]:
+            return int(row["id"])
+    return None
+
+
+def _project_id_from(project: dict[str, object]) -> str:
+    reference = project.get("projectReference") if isinstance(project, dict) else None
+    if isinstance(reference, dict):
+        ref_id = reference.get("projectId")
+        if isinstance(ref_id, str) and ref_id:
+            return ref_id
+    for key in ("projectId", "id"):
+        value = project.get(key) if isinstance(project, dict) else None
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _project_label(project: dict[str, object]) -> str:
+    project_id = _project_id_from(project)
+    friendly = project.get("friendlyName") if isinstance(project, dict) else None
+    if isinstance(friendly, str) and friendly and friendly != project_id:
+        return f"{project_id} ({friendly})"
+    return project_id or "<unknown>"
+
+
+def _init(sample_n: int = 3) -> str:
+    print("\n=== Metadata Initialization ===")
+    account_id = _active_account_id()
+    if account_id is None:
+        return "BigQuery へアクセスするには先に /login を実行してください。"
+
+    print("利用可能な BigQuery プロジェクトを取得しています...")
+    try:
+        projects = bq_client.list_projects(account_id=account_id)
+    except bq_client.BigQueryClientError as exc:
+        return f"プロジェクト一覧の取得に失敗しました: {exc}"
+
+    available = [p for p in projects if _project_id_from(p)]
+    if not available:
+        return "利用可能なプロジェクトが見つかりませんでした。"
+
+    print(f"{len(available)} 件のプロジェクトが見つかりました。対象を選択してください (空行でキャンセル)。")
+    for idx, project in enumerate(available, start=1):
+        print(f"  [{idx}] {_project_label(project)}")
+
+    selected: dict[str, object] | None = None
+    while selected is None:
+        try:
+            raw = _prompt_user("project> ").strip()
+        except KeyboardInterrupt:
+            print()
+            return "プロジェクト選択を中断しました。"
+        if not raw:
+            return "プロジェクト選択をキャンセルしました。"
+        if raw.isdigit():
+            idx = int(raw)
+            if 1 <= idx <= len(available):
+                selected = available[idx - 1]
+                break
+        else:
+            for candidate in available:
+                if _project_id_from(candidate) == raw:
+                    selected = candidate
+                    break
+        if selected is None:
+            print("有効な番号または projectId を入力してください。")
+
+    project_id = _project_id_from(selected)
+    print(f"プロジェクト `{project_id}` を選択しました。データセットを確認しています...")
+
+    try:
+        client = bq_client.BQClient(project_id=project_id, account_id=account_id)
+        dataset_ids = client.list_datasets()
+    except bq_client.BigQueryClientError as exc:
+        return f"データセットの取得に失敗しました: {exc}"
+
+    if dataset_ids:
+        print(f"{len(dataset_ids)} 件のデータセットが見つかりました:")
+        for dataset in dataset_ids:
+            print(f"  - {dataset}")
+        try:
+            confirmation = _prompt_user("Enter で続行 (キャンセルするには 'q'): ").strip().lower()
+        except KeyboardInterrupt:
+            print()
+            return "メタデータ生成を中断しました。"
+        if confirmation == "q":
+            return "メタデータ生成をキャンセルしました。"
+    else:
+        print("対象データセットが見つかりませんでした。空のメタデータを生成します。")
+
+    print("BigQuery からメタデータを収集中です...")
+    try:
+        snapshot = bq_client.metadata_snapshot(
+            project_id=project_id,
+            account_id=account_id,
+            location=client.location,
+            datasets=list(dataset_ids),
+            sample_n=sample_n,
+        )
+    except bq_client.BigQueryClientError as exc:
+        return f"メタデータの取得に失敗しました: {exc}"
+
+    try:
+        result = metadata_manager.save_metadata(snapshot)
+    except Exception as exc:  # pragma: no cover - unexpected filesystem issues
+        return f"メタデータの保存に失敗しました: {exc}"
+
+    message = f"メタデータを生成し {result.path} に保存しました。"
+    if result.backup_path:
+        message += f" 既存ファイルは {result.backup_path} にバックアップしました。"
+    return message
 
 
 def _login() -> str:
@@ -31,4 +155,6 @@ def handle_command(command: str) -> Tuple[bool, str | None]:
         canonical = cmd
     if canonical in {"\\login", "\\reauth"}:
         return True, _login()
+    if canonical == "\\init":
+        return True, _init()
     return False, None

--- a/wise/chat/commands.py
+++ b/wise/chat/commands.py
@@ -1,8 +1,8 @@
-"""Command handlers for chat-mode backslash commands.
+"""Command handlers for chat-mode slash commands.
 
 Currently supports:
-- ``\login``: Re-run minimal setup to update the refresh token
-- ``\init``: Generate BigQuery metadata markdown via the metadata manager
+- ``/login``: Re-run minimal setup to update the refresh token
+- ``/init``: Generate BigQuery metadata markdown via the metadata manager
 """
 
 from __future__ import annotations
@@ -143,18 +143,13 @@ def _login() -> str:
 
 
 def handle_command(command: str) -> Tuple[bool, str | None]:
-    """Handle a backslash command.
+    """Handle a slash command.
 
     Returns (handled, reply). If not handled, (False, None).
     """
     cmd = command.strip()
-    # Normalize leading prefix to support both "/" and "\\"
-    if cmd.startswith("/"):
-        canonical = "\\" + cmd[1:]
-    else:
-        canonical = cmd
-    if canonical in {"\\login", "\\reauth"}:
+    if cmd in {"/login", "/reauth"}:
         return True, _login()
-    if canonical == "\\init":
+    if cmd == "/init":
         return True, _init()
     return False, None

--- a/wise/chat/session.py
+++ b/wise/chat/session.py
@@ -55,8 +55,8 @@ def start_session() -> None:
         if text.lower() in {"exit", "quit"}:
             print("assistant> Goodbye!")
             break
-        if text.startswith("\\") or text.startswith("/"):
-            # Commands like \login handled here
+        if text.startswith("/"):
+            # Commands like /login handled here
             handled, reply = handle_command(text)
             if handled:
                 if reply:

--- a/wise/datastore/files.py
+++ b/wise/datastore/files.py
@@ -1,9 +1,71 @@
-"""File datastore utilities."""
+"""Utilities for writing artifacts to the local datastore."""
 
 from __future__ import annotations
 
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Union
 
-def save(path: str, content: str) -> None:
-    """Mock save content to a path."""
-    _ = (path, content)
-    return
+PROJECT_ROOT_DIRNAME = "project"
+PathLike = Union[str, Path]
+
+
+def _base_dir(base_dir: Optional[PathLike] = None) -> Path:
+    """Return the base directory used for storing project artifacts."""
+
+    if base_dir is not None:
+        return Path(base_dir)
+    return Path.cwd()
+
+
+def ensure_directory(path: Path) -> Path:
+    """Create ``path`` (and parents) when it does not yet exist."""
+
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def project_root(project_id: str, *, base_dir: Optional[PathLike] = None) -> Path:
+    """Return the directory that stores outputs for ``project_id``."""
+
+    if not project_id:
+        raise ValueError("project_id は必須です。")
+    return _base_dir(base_dir) / PROJECT_ROOT_DIRNAME / project_id
+
+
+def metadata_path(project_id: str, *, base_dir: Optional[PathLike] = None) -> Path:
+    """Return the metadata.md path for ``project_id``."""
+
+    return project_root(project_id, base_dir=base_dir) / "metadata.md"
+
+
+def write_text(path: PathLike, content: str) -> Path:
+    """Write ``content`` to ``path`` ensuring parent directories exist."""
+
+    target = Path(path)
+    ensure_directory(target.parent)
+    target.write_text(content, encoding="utf-8")
+    return target
+
+
+def _timestamp_for_backup() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+
+
+def create_backup(path: PathLike) -> Path:
+    """Create a timestamped backup copy of ``path`` and return it."""
+
+    source = Path(path)
+    if not source.exists():
+        raise FileNotFoundError(f"バックアップ対象が存在しません: {source}")
+    backup = source.with_name(f"{source.name}.bak.{_timestamp_for_backup()}")
+    ensure_directory(backup.parent)
+    shutil.copy2(source, backup)
+    return backup
+
+
+def save(path: PathLike, content: str) -> Path:
+    """Compatibility wrapper around :func:`write_text`."""
+
+    return write_text(path, content)

--- a/wise/metadata/manager.py
+++ b/wise/metadata/manager.py
@@ -1,8 +1,172 @@
-"""Metadata manager placeholder."""
+"""Render and persist BigQuery metadata snapshots."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
 
-def load_metadata() -> dict:
-    """Return mock metadata."""
-    return {}
+from ..datastore import files as datastore_files
+
+__all__ = ["MetadataWriteResult", "render_metadata", "save_metadata"]
+
+
+@dataclass(frozen=True)
+class MetadataWriteResult:
+    """Result of writing a metadata document to disk."""
+
+    path: Path
+    backup_path: Path | None = None
+
+
+def _current_timestamp() -> str:
+    """Return an ISO8601 UTC timestamp without microseconds."""
+
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _escape_table_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value)
+    return text.replace("|", "\\|").replace("\n", "<br>")
+
+
+def _render_schema(fields: Iterable[dict[str, Any]]) -> list[str]:
+    lines = ["", "#### フィールド定義", ""]
+    field_list = list(fields or [])
+    if not field_list:
+        lines.append("_スキーマ情報が利用できません。_")
+        lines.append("")
+        return lines
+
+    lines.append("| 名前 | 型 | モード | 説明 |")
+    lines.append("| --- | --- | --- | --- |")
+    for field in field_list:
+        lines.append(
+            "| {name} | {type} | {mode} | {description} |".format(
+                name=_escape_table_cell(field.get("name")),
+                type=_escape_table_cell(field.get("type")),
+                mode=_escape_table_cell(field.get("mode")),
+                description=_escape_table_cell(field.get("description")),
+            )
+        )
+    lines.append("")
+    return lines
+
+
+def _schema_column_names(fields: Iterable[dict[str, Any]]) -> list[str]:
+    names = [f.get("name") for f in fields if f.get("name")]
+    return [str(name) for name in names if name]
+
+
+def _render_sample_rows(fields: Iterable[dict[str, Any]], rows: Iterable[dict[str, Any]]) -> list[str]:
+    lines = ["", "#### サンプル行", ""]
+    row_list = list(rows or [])
+    if not row_list:
+        lines.append("_サンプル行は取得できませんでした。_")
+        lines.append("")
+        return lines
+
+    columns = _schema_column_names(fields)
+    if not columns:
+        keys = set()
+        for row in row_list:
+            keys.update(key for key in row.keys() if key)
+        columns = sorted(keys)
+
+    if not columns:
+        lines.append("_サンプル行を表形式で表示できません。_")
+        lines.append("")
+        return lines
+
+    header = "| " + " | ".join(_escape_table_cell(col) for col in columns) + " |"
+    separator = "| " + " | ".join("---" for _ in columns) + " |"
+    lines.extend([header, separator])
+    for row in row_list:
+        values = [_escape_table_cell(row.get(col)) for col in columns]
+        lines.append("| " + " | ".join(values) + " |")
+    lines.append("")
+    return lines
+
+
+def _render_dataset(dataset_id: str, dataset_entry: dict[str, Any]) -> list[str]:
+    lines = ["", f"## データセット `{dataset_id}`", ""]
+    tables = dataset_entry.get("tables") or {}
+    if not tables:
+        lines.append("_テーブルが存在しません。_")
+        lines.append("")
+        return lines
+
+    for table_id, table_entry in sorted(tables.items()):
+        lines.extend(
+            [
+                "",
+                f"### テーブル `{dataset_id}.{table_id}`",
+            ]
+        )
+        schema = table_entry.get("schema") or []
+        samples = table_entry.get("sampleRows") or []
+        lines.extend(_render_schema(schema))
+        lines.extend(_render_sample_rows(schema, samples))
+    return lines
+
+
+def render_metadata(snapshot: dict[str, Any]) -> str:
+    """Render a Markdown document from ``metadata_snapshot`` output."""
+
+    if not snapshot:
+        raise ValueError("snapshot が空です。")
+    project_id = snapshot.get("projectId")
+    if not project_id:
+        raise ValueError("snapshot には projectId が必要です。")
+
+    location = snapshot.get("location") or "未指定"
+    datasets = snapshot.get("datasets") or {}
+    dataset_items = sorted(datasets.items(), key=lambda item: item[0])
+    generated_at = _current_timestamp()
+
+    lines: list[str] = [f"# BigQuery メタデータ: `{project_id}`", "", "## プロジェクト概要", ""]
+    lines.append(f"- プロジェクト ID: `{project_id}`")
+    lines.append(f"- ロケーション: `{location}`")
+    lines.append(f"- データセット数: {len(dataset_items)}")
+    lines.append(f"- 生成日時 (UTC): {generated_at}")
+    lines.append("")
+    lines.append("## 対象データセット一覧")
+    lines.append("")
+
+    if dataset_items:
+        lines.append("| データセット ID | テーブル数 |")
+        lines.append("| --- | --- |")
+        for dataset_id, dataset_entry in dataset_items:
+            tables = dataset_entry.get("tables") or {}
+            lines.append(f"| `{dataset_id}` | {len(tables)} |")
+    else:
+        lines.append("_データセットが見つかりませんでした。_")
+    lines.append("")
+
+    for dataset_id, dataset_entry in dataset_items:
+        lines.extend(_render_dataset(dataset_id, dataset_entry))
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def save_metadata(
+    snapshot: dict[str, Any],
+    *,
+    base_dir: Path | str | None = None,
+    backup: bool = True,
+) -> MetadataWriteResult:
+    """Persist rendered metadata to ``project/{project_id}/metadata.md``."""
+
+    content = render_metadata(snapshot)
+    project_id = snapshot.get("projectId")
+    if not project_id:
+        raise ValueError("snapshot には projectId が必要です。")
+    path = datastore_files.metadata_path(str(project_id), base_dir=base_dir)
+    backup_path: Path | None = None
+    if backup and path.exists():
+        backup_path = datastore_files.create_backup(path)
+    datastore_files.write_text(path, content)
+    return MetadataWriteResult(path=path, backup_path=backup_path)


### PR DESCRIPTION
## Summary
- add a BigQuery project listing helper, shared datastore utilities, and a rich metadata manager that renders project snapshots to markdown with backups
- wire the `/init` chat command to drive project selection, dataset enumeration, metadata snapshot capture, and file generation with user prompts
- cover the new flow with pytest units for CLI behaviors and metadata rendering/backups

## Testing
- PYENV_VERSION=3.10.17 python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9fca8ce00832789c627ff9c174f30